### PR TITLE
Loosen requirement to just illuminate/database

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "laravel/framework": "^5.5"
+        "illuminate/database": "5.5.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
To avoid collisions elsewhere in the framework, I've narrowed the dependency of this project to just `illuminate/database`, rather than the entire framework.