### PR TITLE
Loosen illuminate/database constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/database": "5.5.*"
+        "illuminate/database": "~5.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This will allow us to shift the dependency to `mithrandir` and support multiple versions of Laravel.